### PR TITLE
change 'PayPal for Marketplaces' to 'PayPal for Partners' in referenc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PayPal for Marketplaces Connected Path PHP Demo
+# PayPal for Partners Connected Path PHP Demo
 
-> **Important:** PayPal for Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
+> **Important:** PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
 
 ## Prerequisites
 

--- a/include/incl.header.php
+++ b/include/incl.header.php
@@ -136,7 +136,7 @@
 				<div class="container-fluid">
 
 					<div class="well bg-color">
-						<h2 class="text-center">PayPal for Marketplaces &bull; <a href="../index.php#readme" class="light-links">Readme</a></h2>
+						<h2 class="text-center">PayPal for Partners &bull; <a href="../index.php#readme" class="light-links">Readme</a></h2>
 					</div>
 
 				</div>

--- a/include/incl.indexheader.php
+++ b/include/incl.indexheader.php
@@ -136,7 +136,7 @@ $mode = (isset($_REQUEST["mode"]) &&  $_REQUEST["mode"] == "isu") ? "isu" : "ma"
 <div class="container-fluid">
 
     <div class="well bg-color">
-        <h2 class="text-center">PayPal for Marketplaces &bull; <a href="#readme" class="light-links">Readme</a></h2>
+        <h2 class="text-center">PayPal for Partners &bull; <a href="#readme" class="light-links">Readme</a></h2>
     </div>
 
 </div>

--- a/include/incl.readme.php
+++ b/include/incl.readme.php
@@ -1,11 +1,11 @@
 <h3>Readme</h3>
 
 <br />
-<b>Important:</b> PayPal for Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
+<b>Important:</b> PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
 <br/><br/>
 
 <h4>Getting Started</h4>
-This code sample serves as a reference for PayPal for Marketplaces APIs. You will need your own PayPal Sandbox Partner credentials to run the code sample.
+This code sample serves as a reference for PayPal for Partners APIs. You will need your own PayPal Sandbox Partner credentials to run the code sample.
 Once you have your Partner credentials, refer to the steps below:
 <br />
 <br />
@@ -139,7 +139,7 @@ A marketplace model in which each individual merchant must have a PayPal account
 
 <h4>Documentation</h4>
 
-PayPal for Marketplaces: <a href="https://developer.paypal.com/docs/marketplaces/pp4mp/" target="_blank">https://developer.paypal.com/docs/marketplaces/pp4mp/</a>
+PayPal for Partners: <a href="https://developer.paypal.com/docs/partners/" target="_blank">https://developer.paypal.com/docs/partners/</a>
 
 <br />
 <br />


### PR DESCRIPTION
…es- links, instructions

### Problem

'PayPal for Marketplaces' references need to be changed to 'PayPal for Partners' as per the new rebranding.

### Solution

All references changed to the new title in instructions, links, headers, etc.
