### PR TITLE
PayPal Commerce Platform change

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-###The PayPal Commerce Platform Connected PHP code sample is released under the following license:
+###The PayPal Commerce Platform - Connected PHP code sample is released under the following license:
 
     Copyright (c) 2013-2016 PAYPAL, INC.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-###The Markeplaces Connected PHP code sample is released under the following license:
+###The PayPal Commerce Platform Connected PHP code sample is released under the following license:
 
     Copyright (c) 2013-2016 PAYPAL, INC.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PayPal Commerce Platform Connected Path PHP Demo
 
-> **Important:** PayPal Commerce Platform is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
+> **Important:** PayPal Commerce Platform for eCommerce Solution Providers and Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PayPal for Partners Connected Path PHP Demo
+# PayPal Commerce Platform Connected Path PHP Demo
 
-> **Important:** PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
+> **Important:** PayPal Commerce Platform is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
 
 ## Prerequisites
 

--- a/api/Config/DataFactory.php
+++ b/api/Config/DataFactory.php
@@ -47,7 +47,7 @@ abstract class DataFactory {
                         'name' => 'Legal Business Name'
                     )
                 ),
-                'business_description' => 'Sample pre-fill merchant for PayPal Marketplace Demo',
+                'business_description' => 'Sample pre-fill merchant for the Demo',
                 'event_dates' => array (
                     array (
                         'event_type' => 'ESTABLISHED',

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 /*
-    * Marketplace Homepage
+    * PayPal Commerce Platform Homepage
 */
 
 $rootPath = "";

--- a/templates/readme.php
+++ b/templates/readme.php
@@ -2,7 +2,7 @@
     <h3>Readme</h3>
 
     <br />
-    <b>Important:</b> PayPal Commerce Platform is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
+    <b>Important:</b> PayPal Commerce Platform for eCommerce Solution Providers and Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
     <br/><br/>
 
     <h4>Getting Started</h4>

--- a/templates/readme.php
+++ b/templates/readme.php
@@ -2,7 +2,7 @@
     <h3>Readme</h3>
 
     <br />
-    <b>Important:</b> PayPal for Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
+    <b>Important:</b> PayPal Commerce Platform is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
     <br/><br/>
 
     <h4>Getting Started</h4>


### PR DESCRIPTION
### Problem

PayPal for Partners rebranded as PayPal Commerce Platform

### Solution

Updated references with correct product name
